### PR TITLE
Fix bug with flashcard images

### DIFF
--- a/frontend/src/flashcards/FlashcardBack.js
+++ b/frontend/src/flashcards/FlashcardBack.js
@@ -1,33 +1,28 @@
 import React from 'react';
 
-/*
-  Styling for the back of the flashcard.
-*/
-const backStyle={
-  borderRadius: "30px",
-  position: "absolute",
-  width: "300px",
-  height: "350px",
-  boxShadow: "rgba(0, 0, 0, 0.2) 0px 1px 8px",
-  fontFamily: "'Montserrat', sans-serif",
-  fontSize: "30px",
-  fontWeight: "600",
-  textAlign: "center",
-  display: "flex",
-  flexDirection: "column",
-  justifyContent: "center",
-  backgroundColor: "#3385E4",
-  color: "white",
+const backStyle = {
+	borderRadius: '30px',
+	position: 'absolute',
+	width: '300px',
+	height: '350px',
+	boxShadow: 'rgba(0, 0, 0, 0.2) 0px 1px 8px',
+	fontFamily: "'Montserrat', sans-serif",
+	fontSize: '30px',
+	fontWeight: '600',
+	textAlign: 'center',
+	display: 'flex',
+	flexDirection: 'column',
+	justifyContent: 'center',
+	backgroundColor: '#3385E4',
+	color: 'white',
 };
 
-class FlashcardBack extends React.Component {
-    render() {
-      return (
-        <div className="FlashcardBack" style={backStyle}>
-          {this.props.text}
-        </div>
-      );
-    }
-  }
+function FlashcardBack(props) {
+	return (
+		<div className="FlashcardBack" style={backStyle}>
+			{this.props.text}
+		</div>
+	);
+}
 
 export default FlashcardBack;

--- a/frontend/src/flashcards/FlashcardFront.js
+++ b/frontend/src/flashcards/FlashcardFront.js
@@ -1,7 +1,7 @@
-import React from 'react';
+import React from "react";
 
 /* Styling for the front of the flashcard*/
-const frontStyle={
+const frontStyle = {
   borderRadius: "30px",
   position: "absolute",
   width: "300px",
@@ -16,35 +16,40 @@ const frontStyle={
   display: "flex",
   flexDirection: "column",
   justifyContent: "center",
-  alignItems:"center"
+  alignItems: "center",
 };
 /*
   Styling for the image inside the flashcard
 */
-const imgStyle={
+const imgStyle = {
   display: "block",
   maxWidth: "150px",
-  maxHeight:"150px",
-  width:"auto",
+  maxHeight: "150px",
+  width: "auto",
   height: "auto",
-  margin:"10px",
+  margin: "10px",
 };
 
 class FlashcardFront extends React.Component {
-    constructor(props) {
-      super(props);
-      this.state = {
-      }
-    }
-  
-    render() {
-      return (
-        <div className="FlashcardFront" style={frontStyle}>
-          <img src={this.props.image} alt={this.props.text} style={imgStyle}/>
-          {this.props.text}
-        </div>
-      );
-    }
+  constructor(props) {
+    super(props);
+    this.state = {};
   }
+
+  render() {
+    return (
+      <div className="FlashcardFront" style={frontStyle}>
+        {this.props.image ? (
+          <img
+            style={imgStyle}
+            src={this.props.image}
+            alt="Can not fetch image"
+          />
+        ) : null}
+        {this.props.text}
+      </div>
+    );
+  }
+}
 /*<img src={this.props.image}/>*/
 export default FlashcardFront;

--- a/frontend/src/flashcards/FlashcardFront.js
+++ b/frontend/src/flashcards/FlashcardFront.js
@@ -1,54 +1,38 @@
-import React from "react";
+import React from 'react';
 
-/* Styling for the front of the flashcard*/
 const frontStyle = {
-  borderRadius: "30px",
-  position: "absolute",
-  width: "300px",
-  height: "350px",
-  backgroundColor: "white",
-  color: "black",
-  boxShadow: "rgba(0, 0, 0, 0.2) 0px 1px 8px",
-  fontFamily: "'Montserrat', sans-serif",
-  fontSize: "30px",
-  fontWeight: "600",
-  textAlign: "center",
-  display: "flex",
-  flexDirection: "column",
-  justifyContent: "center",
-  alignItems: "center",
+	borderRadius: '30px',
+	position: 'absolute',
+	width: '300px',
+	height: '350px',
+	backgroundColor: 'white',
+	color: 'black',
+	boxShadow: 'rgba(0, 0, 0, 0.2) 0px 1px 8px',
+	fontFamily: "'Montserrat', sans-serif",
+	fontSize: '30px',
+	fontWeight: '600',
+	textAlign: 'center',
+	display: 'flex',
+	flexDirection: 'column',
+	justifyContent: 'center',
+	alignItems: 'center',
 };
-/*
-  Styling for the image inside the flashcard
-*/
+
 const imgStyle = {
-  display: "block",
-  maxWidth: "150px",
-  maxHeight: "150px",
-  width: "auto",
-  height: "auto",
-  margin: "10px",
+	display: 'block',
+	maxWidth: '150px',
+	maxHeight: '150px',
+	width: 'auto',
+	height: 'auto',
+	margin: '10px',
 };
 
-class FlashcardFront extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {};
-  }
-
-  render() {
-    return (
-      <div className="FlashcardFront" style={frontStyle}>
-        {this.props.image ? (
-          <img
-            style={imgStyle}
-            src={this.props.image}
-            alt="Can not fetch image"
-          />
-        ) : null}
-        {this.props.text}
-      </div>
-    );
-  }
+function FlashcardFront(props) {
+	return (
+		<div className="FlashcardFront" style={frontStyle}>
+			{this.props.image ? <img style={imgStyle} src={this.props.image} alt="Can not fetch image" /> : null}
+			{this.props.text}
+		</div>
+	);
 }
 export default FlashcardFront;

--- a/frontend/src/flashcards/FlashcardFront.js
+++ b/frontend/src/flashcards/FlashcardFront.js
@@ -51,5 +51,4 @@ class FlashcardFront extends React.Component {
     );
   }
 }
-/*<img src={this.props.image}/>*/
 export default FlashcardFront;


### PR DESCRIPTION
Previously, flashcards would display alternative text when no images were passed in as props, which was not really ideal.
Before:
![image](https://user-images.githubusercontent.com/32044772/89804283-ce803d00-dae8-11ea-9033-7d99b402c805.png)
After:
![Screenshot 2020-08-10 at 9 02 02 AM](https://user-images.githubusercontent.com/32044772/89804203-b14b6e80-dae8-11ea-9995-3dd9f452b217.png)
